### PR TITLE
Remove trailing comma for the last item in json

### DIFF
--- a/docs/data/index.json
+++ b/docs/data/index.json
@@ -31,7 +31,7 @@
             "title": "Paper Title",
             "authors": "Person1, Person2, ...",
             "venue": "Journal or Conference Name",
-            "doi": "#",
+            "doi": "#"
         }
     ],
     "tags": ["Web", "Embedded Systems"]


### PR DESCRIPTION
This caused many parse failures in api.ce.pdn.ac.lk
Then the projects didnt update properly in projects.ce.pdn.ac.lk
https://github.com/cepdnaclk/api.ce.pdn.ac.lk/runs/6843063543?check_suite_focus=true
![image](https://user-images.githubusercontent.com/73381996/173187399-4e087398-1eae-467e-bf3a-b6bae8c23c94.png)


@NuwanJ 